### PR TITLE
Bugfix: document_similarity.py

### DIFF
--- a/src/document_similarity.py
+++ b/src/document_similarity.py
@@ -8,7 +8,7 @@ from scipy.stats import entropy
 from scipy.spatial.distance import jensenshannon
 
 print("Imported")
-corpus = pickle.load(open(r"Database\corpus_file.pkl", "rb"))
+corpus = pickle.load(open(r"DataBase/corpus_file.pkl", "rb"))
 
 
 def train_lda(corpus):


### PR DESCRIPTION
Line 11 to open the corpus_file pickle should: 1) use a forward rather than backlash and 2) "Database" > "DataBase"